### PR TITLE
Illuminate\Contracts\Routing\Middleware is deprecated for Laravel 5.2 or later

### DIFF
--- a/src/SavableMiddleware.php
+++ b/src/SavableMiddleware.php
@@ -2,9 +2,8 @@
 namespace IonutMilica\LaravelSettings;
 
 use Closure;
-use Illuminate\Contracts\Routing\TerminableMiddleware;
 
-class SavableMiddleware implements TerminableMiddleware
+class SavableMiddleware
 {
     /**
      * @var SettingsContract


### PR DESCRIPTION
Instead of implementing the interface, simply define a terminate method on your middleware.
https://laravel.com/docs/5.2/upgrade
